### PR TITLE
Small fix

### DIFF
--- a/rly.c
+++ b/rly.c
@@ -57,7 +57,7 @@ int main(int argc, const char *const *argv) {
   if (r) { fputs("getuid mismatch",stderr); exit(-1); }
   r= geteuid(); if (r<0) { perror("geteuid failed"); exit(-1); }
   if (r) { fputs("geteuid mismatch",stderr); exit(-1); }
-  execvp(argv[0],(char**)argv);
+  execve(argv[0],(char**)argv);
   perror("exec failed");
   exit(-1);
 }


### PR DESCRIPTION
According to `flawfinder` :

```console
rly.c:60:  [4] (shell) execvp:
  This causes a new program to execute and is difficult to use safely
  (CWE-78). try using a library call that implements the same functionality
  if available.
  ```
  
  So I changed it to `execve` to make it safer.